### PR TITLE
Adds a helpful tooltip for name mapping between Ruby/JS component

### DIFF
--- a/docs/custom-reactivity/custom-vue-js-components.md
+++ b/docs/custom-reactivity/custom-vue-js-components.md
@@ -147,6 +147,10 @@ class SomeComponent < Matestack::Ui::VueJsComponent
 end
 ```
 
+{% hint style="info" %}
+`vue_name` should match the name your registered the Vue JS component with on the Vue app instance.
+{% endhint %}
+
 ### Passing data to the Vue.js JavaScript component
 
 Like seen above, matestack renders a `component-config` prop as an attribute of the component tag. In order to fill in some date there, you should use the `setup` method like this:

--- a/docs/custom-reactivity/custom-vue-js-components.md
+++ b/docs/custom-reactivity/custom-vue-js-components.md
@@ -148,7 +148,7 @@ end
 ```
 
 {% hint style="info" %}
-`vue_name` should match the name your registered the Vue JS component with on the Vue app instance.
+`vue_name` should match the name you registered the Vue.js Javascript component with on the Vue.js app instance.
 {% endhint %}
 
 ### Passing data to the Vue.js JavaScript component


### PR DESCRIPTION
### Changes

Adds an info-box to understand where the Ruby component picks up the right Vue JS component from based on naming.

### Notes

Found it very intuitive to understand where and how Matestack maps the vue_name and picks the right component. After some clarifications from the core team, understanding how the Ruby component picks up the right Vue JS
component, was a real step forward in understanding the underlying implementation and removes a bit of the
black-box magic.

Personally, I find this a very neat fact to know. It might have been mentioned above but tried to
make it as concrete and digestible in a little helpful info-box.